### PR TITLE
Fix leftover detached ropes and update line positions

### DIFF
--- a/Match3/Assets/Prefabs/Rope/Rope.prefab
+++ b/Match3/Assets/Prefabs/Rope/Rope.prefab
@@ -1,0 +1,109 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400000}
+  - component: {fileID: 12000000}
+  - component: {fileID: 11400000}
+  m_Layer: 6
+  m_Name: Rope
+  m_TagString: Rope
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!120 &12000000
+LineRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_Materials:
+  - {fileID: 0}
+  m_UseWorldSpace: 1
+  m_Parameters:
+    serializedVersion: 2
+    widthMultiplier: 0.1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+      - time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 1, g: 1, b: 1, a: 1}
+      key3: {r: 1, g: 1, b: 1, a: 1}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      mode: 0
+      numColorKeys: 2
+      numAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    shadowBias: 0
+    generateLightingData: 0
+  m_Positions: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db31470101b34a6cb0f3377ad8fbafb0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  startPoint: {fileID: 0}
+  endPoint: {fileID: 0}
+  segmentPrefab: {fileID: 0}
+  segmentCount: 15
+  segmentLength: 0.2
+  ropeLayer:
+    serializedVersion: 2
+    m_Bits: 0

--- a/Match3/Assets/Prefabs/Rope/Rope.prefab.meta
+++ b/Match3/Assets/Prefabs/Rope/Rope.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 321c2489cdac4529b69447ccda3ea2fb
+timeCreated: 1712018000
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/Assets/Prefabs/Rope/RopeSegment.prefab
+++ b/Match3/Assets/Prefabs/Rope/RopeSegment.prefab
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400000}
+  - component: {fileID: 21200000}
+  - component: {fileID: 6000000}
+  - component: {fileID: 5000000}
+  - component: {fileID: 2500000}
+  m_Layer: 6
+  m_Name: RopeSegment
+  m_TagString: Rope
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!212 &21200000
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_Materials:
+  - {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastPadding: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 0000000000000000f000000000000000, type: 0}
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteSortPoint: 0
+--- !u!60 &6000000
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  serializedVersion: 2
+  m_Density: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.05
+--- !u!50 &5000000
+Rigidbody2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  serializedVersion: 4
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepMode: 0
+  m_CollisionDetection: 0
+  m_UsedByComposite: 0
+  m_AutoMass: 0
+--- !u!251 &2500000
+DistanceJoint2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 100000}
+  m_ConnectedBody: {fileID: 0}
+  m_Anchor: {x: 0, y: 0}
+  m_ConnectedAnchor: {x: 0, y: 0}
+  m_AutoConfigureConnectedAnchor: 1
+  m_AutoConfigureDistance: 1
+  m_MaxDistanceOnly: 0
+  m_BreakForce: 0
+  m_BreakTorque: 0
+  m_EnableCollision: 0
+  m_Distance: 0

--- a/Match3/Assets/Prefabs/Rope/RopeSegment.prefab.meta
+++ b/Match3/Assets/Prefabs/Rope/RopeSegment.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bf1dfe1c33994b06b63efe8ef7b5ce1a
+timeCreated: 1712018000
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/Assets/Scenes/RopeDemo.unity
+++ b/Match3/Assets/Scenes/RopeDemo.unity
@@ -1,0 +1,689 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 705507994}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &705507993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705507995}
+  - component: {fileID: 705507994}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &705507994
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &705507995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &963194225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963194228}
+  - component: {fileID: 963194227}
+  - component: {fileID: 963194226}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963194226
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+--- !u!20 &963194227
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &963194228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &102000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 102000001}
+  - component: {fileID: 102000002}
+  m_Layer: 6
+  m_Name: Anchor1
+  m_TagString: Rope
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &102000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &102000002
+Rigidbody2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102000000}
+  serializedVersion: 4
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepMode: 0
+  m_CollisionDetection: 0
+  m_UsedByComposite: 0
+  m_AutoMass: 0
+--- !u!1 &103000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 103000001}
+  - component: {fileID: 103000002}
+  m_Layer: 6
+  m_Name: Anchor2
+  m_TagString: Rope
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &103000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 103000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &103000002
+Rigidbody2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 103000000}
+  serializedVersion: 4
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepMode: 0
+  m_CollisionDetection: 0
+  m_UsedByComposite: 0
+  m_AutoMass: 0
+--- !u!1 &112000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 112000001}
+  - component: {fileID: 112000002}
+  - component: {fileID: 112000003}
+  m_Layer: 6
+  m_Name: Rope1
+  m_TagString: Rope
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &112000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 112000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &112000002
+LineRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 112000000}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_Materials:
+  - {fileID: 0}
+  m_UseWorldSpace: 1
+  m_Parameters:
+    serializedVersion: 2
+    widthMultiplier: 0.05
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+      - time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 1, g: 1, b: 1, a: 1}
+      key3: {r: 1, g: 1, b: 1, a: 1}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      mode: 0
+      numColorKeys: 2
+      numAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    shadowBias: 0
+    generateLightingData: 0
+  m_Positions: []
+--- !u!114 &112000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 112000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db31470101b34a6cb0f3377ad8fbafb0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  startPoint: {fileID: 102000001}
+  endPoint: {fileID: 0}
+  segmentPrefab: {fileID: 100000, guid: bf1dfe1c33994b06b63efe8ef7b5ce1a, type: 3}
+  segmentCount: 15
+  segmentLength: 0.2
+  ropeLayer:
+    serializedVersion: 2
+    m_Bits: 64
+--- !u!1 &113000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 113000001}
+  - component: {fileID: 113000002}
+  - component: {fileID: 113000003}
+  m_Layer: 6
+  m_Name: Rope2
+  m_TagString: Rope
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &113000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &113000002
+LineRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113000000}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_Materials:
+  - {fileID: 0}
+  m_UseWorldSpace: 1
+  m_Parameters:
+    serializedVersion: 2
+    widthMultiplier: 0.05
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+      - time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 1, g: 1, b: 1, a: 1}
+      key3: {r: 1, g: 1, b: 1, a: 1}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      mode: 0
+      numColorKeys: 2
+      numAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    shadowBias: 0
+    generateLightingData: 0
+  m_Positions: []
+--- !u!114 &113000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db31470101b34a6cb0f3377ad8fbafb0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  startPoint: {fileID: 103000001}
+  endPoint: {fileID: 0}
+  segmentPrefab: {fileID: 100000, guid: bf1dfe1c33994b06b63efe8ef7b5ce1a, type: 3}
+  segmentCount: 15
+  segmentLength: 0.2
+  ropeLayer:
+    serializedVersion: 2
+    m_Bits: 64
+--- !u!1 &120000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 120000001}
+  - component: {fileID: 120000002}
+  m_Layer: 0
+  m_Name: SwipeManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &120000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &120000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a0710dc81d048bebff3f4e8b54e1be9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ropeLayerMask:
+    serializedVersion: 2
+    m_Bits: 64
+  debugDraw: 0
+--- !u!1 &130000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 130000001}
+  - component: {fileID: 130000002}
+  m_Layer: 0
+  m_Name: RopeConnector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &130000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &130000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a59c4b7d6e2432db9528730515f7a45, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ropeToAttach: {fileID: 113000003}
+  targetRope: {fileID: 112000003}
+  targetSegmentIndex: 7
+  attachToStart: 1

--- a/Match3/Assets/Scenes/RopeDemo.unity.meta
+++ b/Match3/Assets/Scenes/RopeDemo.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fab2a75416944339b8593a07eedf6d1c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Match3/Assets/Scripts/Rope/Rope/DetachedRope.cs
+++ b/Match3/Assets/Scripts/Rope/Rope/DetachedRope.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+// Updates a LineRenderer to follow detached rope segments while they fall
+// and destroys them after a set lifetime.
+public class DetachedRope : MonoBehaviour
+{
+    private List<RopeSegment> segments;
+    private LineRenderer lineRenderer;
+    private float lifetime;
+    private Transform endAnchor;
+    private DistanceJoint2D endJoint;
+    private bool destructionScheduled;
+
+    private void UpdateLine()
+    {
+        if (lineRenderer == null || segments == null)
+            return;
+        int count = segments.Count + (endAnchor != null ? 1 : 0);
+        lineRenderer.positionCount = count;
+        for (int i = 0; i < segments.Count; i++)
+        {
+            if (segments[i] != null)
+                lineRenderer.SetPosition(i, segments[i].transform.position);
+        }
+        if (endAnchor != null)
+            lineRenderer.SetPosition(count - 1, endAnchor.position);
+    }
+    private void ScheduleDestruction(float time)
+    {
+        if (destructionScheduled || time <= 0f)
+            return;
+        destructionScheduled = true;
+        foreach (var seg in segments)
+        {
+            if (seg != null)
+                Destroy(seg.gameObject, time);
+        }
+        Destroy(gameObject, time);
+    }
+
+    // Called by RopeController immediately after creation.
+    public void Initialize(List<RopeSegment> segs, LineRenderer template, float destroyAfter, Transform anchor = null)
+    {
+        segments = segs;
+        lifetime = destroyAfter;
+        endAnchor = anchor;
+        if (endAnchor != null)
+        {
+            Rigidbody2D anchorRb = endAnchor.GetComponent<Rigidbody2D>();
+            foreach (var s in segs)
+            {
+                foreach (var j in s.GetComponents<DistanceJoint2D>())
+                {
+                    if (anchorRb != null && j.connectedBody == anchorRb)
+                    {
+                        endJoint = j;
+                        break;
+                    }
+                    if (anchorRb == null && j.connectedBody == null)
+                    {
+                        endJoint = j;
+                        break;
+                    }
+                }
+                if (endJoint != null)
+                    break;
+            }
+        }
+
+        lineRenderer = GetComponent<LineRenderer>();
+        if (lineRenderer == null)
+        {
+            lineRenderer = gameObject.AddComponent<LineRenderer>();
+        }
+
+        if (template != null)
+        {
+            lineRenderer.widthMultiplier = template.widthMultiplier;
+            lineRenderer.material = template.material;
+            lineRenderer.numCapVertices = template.numCapVertices;
+            lineRenderer.numCornerVertices = template.numCornerVertices;
+            lineRenderer.colorGradient = template.colorGradient;
+            lineRenderer.textureMode = template.textureMode;
+        }
+
+        foreach (var seg in segments)
+        {
+            if (seg != null)
+            {
+                seg.transform.SetParent(transform, true);
+            }
+        }
+
+        UpdateLine();
+        ScheduleDestruction(lifetime);
+    }
+
+    private void Update()
+    {
+        UpdateLine();
+    }
+
+    // Handle further cuts on this detached rope in the same way as RopeController.
+    public void CutRopeAt(GameObject hitSegment)
+    {
+        RopeSegment seg = hitSegment.GetComponent<RopeSegment>();
+        if (seg == null)
+            return;
+
+        int index = segments.IndexOf(seg);
+        if (index == -1)
+        {
+            seg.Cut();
+            return;
+        }
+
+        List<RopeSegment> bottom = segments.GetRange(index, segments.Count - index);
+        segments.RemoveRange(index, segments.Count - index);
+
+        if (lineRenderer != null)
+        {
+            lineRenderer.positionCount = segments.Count + (endAnchor != null ? 1 : 0);
+        }
+
+        UpdateLine();
+
+        seg.Cut();
+
+        bool keepAnchor = false;
+        if (endJoint != null)
+        {
+            RopeSegment anchorSeg = endJoint.GetComponent<RopeSegment>();
+            if (bottom.Contains(anchorSeg))
+            {
+                keepAnchor = true;
+                endJoint = null;
+            }
+        }
+
+        if (bottom.Count > 0)
+        {
+            GameObject temp = new("DetachedRope");
+            DetachedRope dr = temp.AddComponent<DetachedRope>();
+            temp.AddComponent<LineRenderer>();
+            float life = keepAnchor ? -1f : lifetime;
+            dr.Initialize(bottom, lineRenderer, life, keepAnchor ? endAnchor : null);
+        }
+
+        if (keepAnchor)
+        {
+            // anchor moves to the newly spawned detached piece
+            endAnchor = null;
+            if (lineRenderer != null)
+            {
+                lineRenderer.positionCount = segments.Count;
+            }
+            lifetime = 5f;
+            ScheduleDestruction(lifetime);
+        }
+
+        if (segments.Count == 0)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            UpdateLine();
+        }
+    }
+}
+

--- a/Match3/Assets/Scripts/Rope/Rope/DetachedRope.cs.meta
+++ b/Match3/Assets/Scripts/Rope/Rope/DetachedRope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3de1c0221d17429995b80fc411cedb58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/Assets/Scripts/Rope/Rope/RopeConnector.cs
+++ b/Match3/Assets/Scripts/Rope/Rope/RopeConnector.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+// Helper component to connect one rope to a specific segment of another rope.
+// Add this script to any GameObject and assign the ropes in the inspector.
+public class RopeConnector : MonoBehaviour
+{
+    [Tooltip("Rope that will be re-anchored at runtime.")]
+    public RopeController ropeToAttach;
+
+    [Tooltip("Rope providing the segment anchor.")]
+    public RopeController targetRope;
+
+    [Tooltip("Index of the segment on the target rope to use as the anchor.")]
+    public int targetSegmentIndex;
+
+    [Tooltip("Connect to the start of ropeToAttach when true, otherwise the end.")]
+    public bool attachToStart = true;
+
+    private void Start()
+    {
+        if (ropeToAttach == null || targetRope == null)
+            return;
+
+        RopeSegment seg = targetRope.GetSegment(targetSegmentIndex);
+        if (seg == null)
+            return;
+
+        if (attachToStart)
+        {
+            ropeToAttach.AttachStartAnchor(seg.transform);
+        }
+        else
+        {
+            ropeToAttach.AttachEndAnchor(seg.transform);
+        }
+    }
+}

--- a/Match3/Assets/Scripts/Rope/Rope/RopeConnector.cs.meta
+++ b/Match3/Assets/Scripts/Rope/Rope/RopeConnector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a59c4b7d6e2432db9528730515f7a45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/Assets/Scripts/Rope/Rope/RopeController.cs
+++ b/Match3/Assets/Scripts/Rope/Rope/RopeController.cs
@@ -41,6 +41,71 @@ public class RopeController : MonoBehaviour
 
     private readonly List<RopeSegment> segments = new();
     private LineRenderer lineRenderer;
+    private DistanceJoint2D endJoint;
+
+    // Allow other scripts to query segments for dynamic connections
+    public RopeSegment GetSegment(int index)
+    {
+        if (index < 0 || index >= segments.Count)
+            return null;
+        return segments[index];
+    }
+
+    // Attach the rope's starting joint to a different anchor at runtime.
+    public void AttachStartAnchor(Transform newAnchor)
+    {
+        if (segments.Count == 0 || newAnchor == null)
+            return;
+        startPoint = newAnchor;
+        DistanceJoint2D joint = segments[0].GetComponent<DistanceJoint2D>();
+        Rigidbody2D rb = newAnchor.GetComponent<Rigidbody2D>();
+        if (rb != null)
+        {
+            joint.connectedBody = rb;
+            joint.connectedAnchor = Vector2.zero;
+        }
+        else
+        {
+            joint.connectedBody = null;
+            joint.connectedAnchor = newAnchor.position;
+        }
+    }
+
+    // Attach or move the end joint to a new anchor at runtime.
+    public void AttachEndAnchor(Transform newAnchor)
+    {
+        if (segments.Count == 0)
+            return;
+
+        if (endJoint == null)
+        {
+            endJoint = segments[^1].gameObject.AddComponent<DistanceJoint2D>();
+            endJoint.autoConfigureDistance = false;
+            endJoint.distance = segmentLength;
+        }
+
+        endPoint = newAnchor;
+
+        if (newAnchor != null)
+        {
+            Rigidbody2D rb = newAnchor.GetComponent<Rigidbody2D>();
+            if (rb != null)
+            {
+                endJoint.connectedBody = rb;
+                endJoint.connectedAnchor = Vector2.zero;
+            }
+            else
+            {
+                endJoint.connectedBody = null;
+                endJoint.connectedAnchor = newAnchor.position;
+            }
+        }
+        else
+        {
+            Destroy(endJoint);
+            endJoint = null;
+        }
+    }
 
     private void Awake()
     {
@@ -103,7 +168,8 @@ public class RopeController : MonoBehaviour
                 Collider2D col = seg.GetComponent<Collider2D>();
                 if (col != null)
                 {
-                    seg.layer = LayerMask.NameToLayer(LayerMask.LayerToName(ropeLayer));
+                    int layerIndex = (int)Mathf.Log(ropeLayer.value, 2);
+                    seg.layer = layerIndex;
                 }
             }
 
@@ -111,13 +177,25 @@ public class RopeController : MonoBehaviour
             previousBody = rb;
         }
 
-        // Attach end object to last segment if provided
+        // Attach the last segment to the end point if provided.  The joint is
+        // placed on the last segment so the end point itself does not require
+        // a Rigidbody2D (e.g. when it is just a static anchor).
         if (endPoint != null)
         {
-            DistanceJoint2D endJoint = endPoint.gameObject.AddComponent<DistanceJoint2D>();
+            endJoint = segments[^1].gameObject.AddComponent<DistanceJoint2D>();
             endJoint.autoConfigureDistance = false;
             endJoint.distance = segmentLength;
-            endJoint.connectedBody = segments[^1].GetComponent<Rigidbody2D>();
+
+            Rigidbody2D anchorRb = endPoint.GetComponent<Rigidbody2D>();
+            if (anchorRb != null)
+            {
+                endJoint.connectedBody = anchorRb;
+            }
+            else
+            {
+                endJoint.connectedBody = null;
+                endJoint.connectedAnchor = endPoint.position;
+            }
         }
     }
 
@@ -144,9 +222,51 @@ public class RopeController : MonoBehaviour
     public void CutRopeAt(GameObject hitSegment)
     {
         RopeSegment seg = hitSegment.GetComponent<RopeSegment>();
-        if (seg != null)
+        if (seg == null)
+            return;
+
+        int index = segments.IndexOf(seg);
+        if (index == -1)
         {
             seg.Cut();
+            return;
+        }
+
+        // bottom part including the cut segment
+        List<RopeSegment> bottom = segments.GetRange(index, segments.Count - index);
+
+        // remove them from this rope
+        segments.RemoveRange(index, segments.Count - index);
+
+        // shrink the line renderer to the remaining segments
+        if (lineRenderer != null)
+        {
+            lineRenderer.positionCount = segments.Count + 1;
+        }
+
+        // cut only the first segment so the chain stays intact
+        seg.Cut();
+
+        bool keepAnchor = false;
+        if (endJoint != null)
+        {
+            RopeSegment endSeg = endJoint.GetComponent<RopeSegment>();
+            if (bottom.Contains(endSeg))
+            {
+                // piece stays attached to the end object
+                keepAnchor = true;
+                endJoint = null;
+            }
+        }
+
+        // create a temporary object to render the detached piece
+        if (bottom.Count > 0)
+        {
+            GameObject temp = new("DetachedRope");
+            DetachedRope dr = temp.AddComponent<DetachedRope>();
+            temp.AddComponent<LineRenderer>();
+            float lifetime = keepAnchor ? -1f : 5f;
+            dr.Initialize(bottom, lineRenderer, lifetime, keepAnchor ? endPoint : null);
         }
     }
 }

--- a/Match3/Assets/Scripts/Rope/Rope/RopeController.cs.meta
+++ b/Match3/Assets/Scripts/Rope/Rope/RopeController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db31470101b34a6cb0f3377ad8fbafb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/Assets/Scripts/Rope/Rope/RopeSegment.cs.meta
+++ b/Match3/Assets/Scripts/Rope/Rope/RopeSegment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd11f1ddac07408fbfa9e6b397479e09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/Assets/Scripts/Rope/Rope/SwipeSlicer.cs
+++ b/Match3/Assets/Scripts/Rope/Rope/SwipeSlicer.cs
@@ -83,6 +83,14 @@ public class SwipeSlicer : MonoBehaviour
             {
                 rope.CutRopeAt(hit.collider.gameObject);
             }
+            else
+            {
+                DetachedRope dr = hit.collider.GetComponentInParent<DetachedRope>();
+                if (dr != null)
+                {
+                    dr.CutRopeAt(hit.collider.gameObject);
+                }
+            }
         }
     }
 }

--- a/Match3/Assets/Scripts/Rope/Rope/SwipeSlicer.cs.meta
+++ b/Match3/Assets/Scripts/Rope/Rope/SwipeSlicer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a0710dc81d048bebff3f4e8b54e1be9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Match3/ProjectSettings/TagManager.asset
+++ b/Match3/ProjectSettings/TagManager.asset
@@ -3,16 +3,17 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Rope
   layers:
   - Default
   - TransparentFX
   - Ignore Raycast
-  - 
+  -
   - Water
   - UI
-  - 
-  - 
+  - Rope
+  -
   - 
   - 
   - 


### PR DESCRIPTION
## Summary
- clean up DetachedRope objects when their segments are gone
- update line renderer positions right after initializing a detached rope
- schedule destruction when the endpoint anchor transfers
- allow ropes to connect to other rope segments using new methods in `RopeController`
- added `RopeConnector` helper component and demo scene update

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68823c75454c8320b83e4b7a6a2d56d9